### PR TITLE
Mid: pm_pcsgen: Detect Deprecation Warning. (for pm_extra_tools 1.6)

### DIFF
--- a/pm_pcsgen/pm_pcsgen.py
+++ b/pm_pcsgen/pm_pcsgen.py
@@ -1826,6 +1826,8 @@ class Gen:
             return False
       if re.match(r'warning: ',x,flags=re.I) is not None:
         warn(x)
+      elif re.match(r'deprecation warning: ',x,flags=re.I) is not None:
+        warn(x)
       elif x:
         info(x)
       return True


### PR DESCRIPTION
Hi All,

pm_pcsgen does not detect Deprecation Warning on RHEL9.1/RHEL9.2.
This PR fixes pm_extra_tools 1.6 to detect Deprecation Warning.


Best Regards,
Hideo Yamauchi.