### PR TITLE
Fixed the bug detected in UT no.34. See #5546.

### DIFF
--- a/pm_pcsgen/pm_pcsgen.py
+++ b/pm_pcsgen/pm_pcsgen.py
@@ -1945,6 +1945,8 @@ class Gen:
         s.append('%s %s=%s'%(PCSF[tag],x.getAttribute('name'),x.getAttribute('value')))
       elif self.pcs_default == 2:
         s.append('%s update %s=%s'%(PCSF[tag],x.getAttribute('name'),x.getAttribute('value')))
+      else:
+        continue
       self.run_pcs(s[-1],x.getAttribute(ATTR_C))
     if s:
       return '%s\n%s\n'%(CMNT[tag],'\n'.join(s))


### PR DESCRIPTION
When pcs command is not found, the value of variable pcs_default becomes invalid(0).
It causes pm_pcsgen to terminate with an unexpected error.
So,  I have added additional branching to avoid that operation in such cases.