### PR TITLE
Extend the error check to be performed for RHEL9 and later, not only RHEL9.

### DIFF
--- a/pm_pcsgen/pm_pcsgen.py
+++ b/pm_pcsgen/pm_pcsgen.py
@@ -1820,7 +1820,7 @@ class Gen:
         else:
           debug(x,self.filter[k].get('filterreason',None))
       x = '\n'.join(n)
-      if rhelver.rhel_ver == 9:
+      if rhelver.rhel_ver >= 9:
           if p.returncode != 0:
             error(x)
             return False


### PR DESCRIPTION
Enable it to work on RHEL10.