### PR TITLE
Relocate all version numbers to configure.ac for central management.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,8 +13,12 @@ AC_PREREQ([2.69])
 #                     ]))
 #
 #AC_INIT(pm_extra_tools, [CURRENT_VERSION])
-AC_INIT(pm_extra_tools, 1.6)
+m4_define([CURRENT_VERSION], [1.7])
+AC_INIT(pm_extra_tools, [CURRENT_VERSION])
 AM_INIT_AUTOMAKE
+
+PM_PCSGEN_VER=CURRENT_VERSION
+AC_SUBST(PM_PCSGEN_VER)
 
 # Checks for programs.
 AC_PROG_LN_S
@@ -30,5 +34,6 @@ AC_PROG_LN_S
 AC_CONFIG_FILES([Makefile
                  pm_extra_tools.spec
                  pm_pcsgen/Makefile
+                 pm_pcsgen/pm_pcsgen.py
                  resources/Makefile])
 AC_OUTPUT

--- a/pm_pcsgen/pm_pcsgen.py.in
+++ b/pm_pcsgen/pm_pcsgen.py.in
@@ -295,7 +295,7 @@ class Gen:
       description=f"To set 'cluster node (NODE table)', cluster must be live.\n{d}",
       prog='pm_pcsgen',
       formatter_class=argparse.RawTextHelpFormatter)
-    p.add_argument('-$','--version',action='version',version='1.6',
+    p.add_argument('-$','--version',action='version',version='@PM_PCSGEN_VER@',
       help='Print %(prog)s version information.')
     p.add_argument('-V','--verbose',action='count',dest='loglv',default=Log.WARN,
       help='Increase debug output.')


### PR DESCRIPTION
Accordingly, the pm_pcsgen.py file was removed and a corresponding pm_pcsgen.py.in file was created.