### PR TITLE
Update for RHEL 10.0 support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,8 +13,12 @@ AC_PREREQ([2.69])
 #                     ]))
 #
 #AC_INIT(pm_extra_tools, [CURRENT_VERSION])
-AC_INIT(pm_extra_tools, 1.6)
+m4_define([CURRENT_VERSION], [1.7])
+AC_INIT(pm_extra_tools, [CURRENT_VERSION])
 AM_INIT_AUTOMAKE
+
+PM_PCSGEN_VER=CURRENT_VERSION
+AC_SUBST(PM_PCSGEN_VER)
 
 # Checks for programs.
 AC_PROG_LN_S
@@ -30,5 +34,6 @@ AC_PROG_LN_S
 AC_CONFIG_FILES([Makefile
                  pm_extra_tools.spec
                  pm_pcsgen/Makefile
+                 pm_pcsgen/pm_pcsgen.py
                  resources/Makefile])
 AC_OUTPUT

--- a/pm_pcsgen/pm_pcsgen.py.in
+++ b/pm_pcsgen/pm_pcsgen.py.in
@@ -295,7 +295,7 @@ class Gen:
       description=f"To set 'cluster node (NODE table)', cluster must be live.\n{d}",
       prog='pm_pcsgen',
       formatter_class=argparse.RawTextHelpFormatter)
-    p.add_argument('-$','--version',action='version',version='1.6',
+    p.add_argument('-$','--version',action='version',version='@PM_PCSGEN_VER@',
       help='Print %(prog)s version information.')
     p.add_argument('-V','--verbose',action='count',dest='loglv',default=Log.WARN,
       help='Increase debug output.')

--- a/pm_pcsgen/pm_pcsgen.py.in
+++ b/pm_pcsgen/pm_pcsgen.py.in
@@ -1820,7 +1820,7 @@ class Gen:
         else:
           debug(x,self.filter[k].get('filterreason',None))
       x = '\n'.join(n)
-      if rhelver.rhel_ver == 9:
+      if rhelver.rhel_ver >= 9:
           if p.returncode != 0:
             error(x)
             return False
@@ -2118,17 +2118,37 @@ class Gen:
       exp = []
       for y in x.childNodes:
         z = []
+        #
+        # RHEL 10.0 同梱の pcs 0.12 以降、
+        # 'pcs constraint location rule ...'では<expression>をクォートで囲まないとWarning
+        # -> シングルクォートで囲む
+        # -> その場合、'#'のエスケープは行わない
+        #
+        # $ pcs --version
+        # 0.12.0a1
+        # $ pcs constraint location ipaddr-standby rule score=200 pgsql-status eq HS:sync
+        # Deprecation Warning: Specifying a rule as multiple arguments is deprecated and might be removed in a future release, specify the rule as a single string instead
         if y.getAttribute('op').lower() in LOC_RULE_UNARY:
           z.append(y.getAttribute('op'))
-          z.append(y.getAttribute('attribute').replace('#','\#'))
+          if rhelver.rhel_ver >= 10:
+            z.append(y.getAttribute('attribute'))
+          else:
+            z.append(y.getAttribute('attribute').replace('#', r'\#'))
         else:
-          z.append(y.getAttribute('attribute').replace('#','\#'))
+          if rhelver.rhel_ver >= 10:
+            z.append(y.getAttribute('attribute'))
+          else:
+            z.append(y.getAttribute('attribute').replace('#', r'\#'))
           z.append(y.getAttribute('op'))
           z.append(y.getAttribute('value'))
         exp.append(' '.join(z))
       z = f" {x.getAttribute('bool_op')} ".join(exp) if x.getAttribute('bool_op') else exp[0]
-      s.append('%s %s rule%s score=%s %s'%(
-        PCSF[Mode.LOCR.value], l.getAttribute('rsc'), ''.join(role), x.getAttribute('score'), z ))
+      if rhelver.rhel_ver >= 10:
+        s.append('%s %s rule%s score=%s \'%s\''%(
+          PCSF[Mode.LOCR.value], l.getAttribute('rsc'), ''.join(role), x.getAttribute('score'), z ))
+      else:
+        s.append('%s %s rule%s score=%s %s'%(
+          PCSF[Mode.LOCR.value], l.getAttribute('rsc'), ''.join(role), x.getAttribute('score'), z ))
       self.run_pcs(s[-1],x.getAttribute(ATTR_C))
     if s:
       return '%s\n%s\n'%(CMNT[Mode.LOCR.value],'\n'.join(s))


### PR DESCRIPTION
This PR includes 3 changes:

1. Use r"" for regular expressions to avoid SyntaxWarning.
    This is to keep up with the changes in the re module specification since Python 3.6.
2. Add single quotes to enclose the expression part in the "pcs constraint location rule" statement for RHEL10 and later.
    This is to comply with the specification changes since pcs0.12.
    (And when the expression is enclosed, escaping # is not required.)
3. Extend the error check for pcs command to RHEL9 and later, not only RHEL9.